### PR TITLE
fix: Check if tailwindcss is listed package

### DIFF
--- a/src/option.ts
+++ b/src/option.ts
@@ -1,7 +1,7 @@
 import type { StylisticCustomizeOptions } from '@stylistic/eslint-plugin'
 import type { ParserOptions } from '@typescript-eslint/types'
 import defu from 'defu'
-import { getPackageInfo, isPackageExists } from 'local-pkg'
+import { getPackageInfo, isPackageExists, isPackageListed } from 'local-pkg'
 import { readPackageUp } from 'read-package-up'
 
 import { DEFAULT_IGNORE_FILES, GLOB_EXCLUDE } from './consts'
@@ -39,8 +39,12 @@ export async function mergeDefaultOptions(
   const hasExpo = isPackageExists('expo')
   const hasUnocss = isPackageExists('unocss')
 
-  const tailwindPackageInfo = await getPackageInfo('tailwindcss')
-  const hasTailwindCSS = !!tailwindPackageInfo?.version
+  const [tailwindPackageInfo, tailwindPackageListed] = await Promise.all([
+    getPackageInfo('tailwindcss'),
+    isPackageListed('tailwindcss'),
+  ])
+
+  const hasTailwindCSS = tailwindPackageListed && !!tailwindPackageInfo?.version
 
   /// keep-sorted
   const defaultOptions: Required<Options> = {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
Currently, while using `eslint-config-hyoban` in an environment which doesn't include `tailwindcss` in the package, the default config will still try to set `tailwindCSS` as `true`.

This can be verified by having: `Cannot resolve default tailwindcss config path. Please manually set the config option.` warning while using the eslint command.

This behaviour seems to be rising due to `eslint-plugin-tailwindcss` package having the `tailwindcss` dependency, proof :
```
> npm ls tailwindcss
project@1.0.0 C:\project
└─┬ eslint-config-hyoban@4.1.0
  └─┬ eslint-plugin-tailwindcss@4.0.0-beta.0
    ├─┬ tailwind-api-utils@1.0.3
    │ └── tailwindcss@4.1.18 deduped
    └── tailwindcss@4.1.18
```

To fix this issue, we will also use `isPackageListed` to check if `tailwindcss` is included in the project package. 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

`eslint --fix` command usage before the fix:

https://github.com/user-attachments/assets/5ae72ece-2fe9-4b76-a52b-fec21c057995

`eslint --fix` command usage after the fix:

https://github.com/user-attachments/assets/7376a14a-f568-403e-990d-d31c939ad1fb



<!-- e.g. is there anything you'd like reviewers to focus on? -->
